### PR TITLE
fix: w3e 12

### DIFF
--- a/src/parsers/w3x/w3e/corner.ts
+++ b/src/parsers/w3x/w3e/corner.ts
@@ -17,7 +17,7 @@ export default class Corner {
   cliffTexture = 0;
   layerHeight = 0;
 
-  load(stream: BinaryStream): void {
+  load(stream: BinaryStream, version: number): void {
     this.groundHeight = (stream.readInt16() - 8192) / 512;
 
     const waterAndEdge = stream.readInt16();
@@ -25,14 +25,25 @@ export default class Corner {
     this.waterHeight = ((waterAndEdge & 0x3FFF) - 8192) / 512;
     this.mapEdge = waterAndEdge & 0x4000;
 
-    const textureAndFlags = stream.readUint8();
+    if (version >= 12) {
+      const textureAndFlags = stream.readUint16();
 
-    this.ramp = textureAndFlags & 0b00010000;
-    this.blight = textureAndFlags & 0b00100000;
-    this.water = textureAndFlags & 0b01000000;
-    this.boundary = textureAndFlags & 0b10000000;
+      this.ramp = textureAndFlags & 0b0001000000;
+      this.blight = textureAndFlags & 0b0010000000;
+      this.water = textureAndFlags & 0b0100000000;
+      this.boundary = textureAndFlags & 0b1000000000;
 
-    this.groundTexture = textureAndFlags & 0b00001111;
+      this.groundTexture = textureAndFlags & 0b0000111111;
+    } else {
+      const textureAndFlags = stream.readUint8();
+
+      this.ramp = textureAndFlags & 0b00010000;
+      this.blight = textureAndFlags & 0b00100000;
+      this.water = textureAndFlags & 0b01000000;
+      this.boundary = textureAndFlags & 0b10000000;
+
+      this.groundTexture = textureAndFlags & 0b00001111;
+    }
 
     const variation = stream.readUint8();
 
@@ -45,10 +56,12 @@ export default class Corner {
     this.layerHeight = cliffTextureAndLayer & 0b00001111;
   }
 
-  save(stream: BinaryStream): void {
+  save(stream: BinaryStream, version: number): void {
     stream.writeInt16(this.groundHeight * 512 + 8192);
-    stream.writeInt16(this.waterHeight * 512 + 8192 + this.mapEdge << 14);
-    stream.writeUint8((this.ramp << 4) | (this.blight << 5) | (this.water << 6) | (this.boundary << 7) | this.groundTexture);
+    stream.writeInt16(this.waterHeight * 512 + 8192 | this.mapEdge);
+    const textureAndFlags = this.ramp | this.blight | this.water | this.boundary | this.groundTexture;
+    if (version >= 12) stream.writeUint16(textureAndFlags);
+    else stream.writeUint8(textureAndFlags);
     stream.writeUint8((this.cliffVariation << 5) | this.groundVariation);
     stream.writeUint8((this.cliffTexture << 4) + this.layerHeight);
   }

--- a/src/parsers/w3x/w3e/file.ts
+++ b/src/parsers/w3x/w3e/file.ts
@@ -42,7 +42,7 @@ export default class War3MapW3e {
       for (let column = 0, columns = this.mapSize[0]; column < columns; column++) {
         const corner = new Corner();
 
-        corner.load(stream);
+        corner.load(stream, this.version);
 
         this.corners[row][column] = corner;
       }
@@ -74,7 +74,7 @@ export default class War3MapW3e {
 
     for (const row of this.corners) {
       for (const corner of row) {
-        corner.save(stream);
+        corner.save(stream, this.version);
       }
     }
 
@@ -82,6 +82,7 @@ export default class War3MapW3e {
   }
 
   getByteLength(): number {
-    return 37 + (this.groundTilesets.length * 4) + (this.cliffTilesets.length * 4) + (this.mapSize[0] * this.mapSize[1] * 7);
+    const bytesPerCorner = this.version >= 12 ? 8 : 7;
+    return 37 + (this.groundTilesets.length * 4) + (this.cliffTilesets.length * 4) + (this.mapSize[0] * this.mapSize[1] * bytesPerCorner);
   }
 }


### PR DESCRIPTION
Adds support for w3e version 12, released with [patch 2.0.3's 64 tile change](https://us.forums.blizzard.com/en/warcraft3/t/patch-203-build-23101-is-now-live/37162).

Verified byte equality when cloning both v11 and v12 via load and save. Looks like the original save was busted since the corner flags were saved with their byte offset, then byte offset again. Similar issue with water height.